### PR TITLE
Change the way ext_colorlog.py locates its config

### DIFF
--- a/cement/ext/ext_colorlog.py
+++ b/cement/ext/ext_colorlog.py
@@ -64,7 +64,7 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_console_format(self):
         format = super(ColorLogHandler, self)._get_console_format()
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label),
                                        'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
@@ -73,14 +73,14 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_file_format(self):
         format = super(ColorLogHandler, self)._get_file_format()
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label),
                                        'colorize_file_log')
         if is_true(colorize):
             format = "%(log_color)s" + format
         return format
 
     def _get_console_formatter(self, format):
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label),
                                        'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
@@ -99,7 +99,7 @@ class ColorLogHandler(LoggingLogHandler):
         return formatter
 
     def _get_file_formatter(self, format):
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label),
                                        'colorize_file_log')
         if is_true(colorize):
             formatter = self._meta.formatter_class(

--- a/cement/ext/ext_colorlog.py
+++ b/cement/ext/ext_colorlog.py
@@ -64,7 +64,7 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_console_format(self):
         format = super(ColorLogHandler, self)._get_console_format()
-        colorize = self.app.config.get('log.colorlog', 'colorize_console_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
                 format = "%(log_color)s" + format
@@ -72,13 +72,13 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_file_format(self):
         format = super(ColorLogHandler, self)._get_file_format()
-        colorize = self.app.config.get('log.colorlog', 'colorize_file_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_file_log')
         if is_true(colorize):
             format = "%(log_color)s" + format
         return format
 
     def _get_console_formatter(self, format):
-        colorize = self.app.config.get('log.colorlog', 'colorize_console_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
                 formatter = self._meta.formatter_class(
@@ -96,7 +96,7 @@ class ColorLogHandler(LoggingLogHandler):
         return formatter
 
     def _get_file_formatter(self, format):
-        colorize = self.app.config.get('log.colorlog', 'colorize_file_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_file_log')
         if is_true(colorize):
             formatter = self._meta.formatter_class(
                 format,

--- a/cement/ext/ext_colorlog.py
+++ b/cement/ext/ext_colorlog.py
@@ -64,7 +64,8 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_console_format(self):
         format = super(ColorLogHandler, self)._get_console_format()
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_console_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+                                       'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
                 format = "%(log_color)s" + format
@@ -72,13 +73,15 @@ class ColorLogHandler(LoggingLogHandler):
 
     def _get_file_format(self):
         format = super(ColorLogHandler, self)._get_file_format()
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_file_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+                                       'colorize_file_log')
         if is_true(colorize):
             format = "%(log_color)s" + format
         return format
 
     def _get_console_formatter(self, format):
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_console_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+                                       'colorize_console_log')
         if sys.stdout.isatty() or 'CEMENT_TEST' in os.environ:
             if is_true(colorize):
                 formatter = self._meta.formatter_class(
@@ -96,7 +99,8 @@ class ColorLogHandler(LoggingLogHandler):
         return formatter
 
     def _get_file_formatter(self, format):
-        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 'colorize_file_log')
+        colorize = self.app.config.get('log.{}'.format(self.Meta.label), 
+                                       'colorize_file_log')
         if is_true(colorize):
             formatter = self._meta.formatter_class(
                 format,


### PR DESCRIPTION
By having the Meta.label be dynamically fetched when "colorize" is set, one can subclass ColorLogHandler to add further functionality (ie. mailing when a fatal error occurs). 
Now a subclass Handler can be defined, its own class Meta sets the config_defaults and the original ColorLogHandler receives the config from it.


---

**Issue:** #571


[Guidelines for Code Contributions]: https://github.com/datafolklabs/cement/blob/master/.github/CONTRIBUTING.md#guidelines-for-code-contributions
[PEP8]: http://www.python.org/dev/peps/pep-0008/
